### PR TITLE
Do not force the path to come from the resource

### DIFF
--- a/src/main/java/ca/nexapp/core/infrastructure/files/reader/ByLineFileReader.java
+++ b/src/main/java/ca/nexapp/core/infrastructure/files/reader/ByLineFileReader.java
@@ -11,7 +11,7 @@ public class ByLineFileReader implements FileReader<List<String>> {
     @Override
     public List<String> read(String filePath) {
         try {
-            Path pathResource = Paths.get(getClass().getResource(filePath).toURI());
+            Path pathResource = Paths.get(filePath);
             return Files.readAllLines(pathResource, StandardCharsets.UTF_8);
         } catch (Exception e) {
             throw new IllegalArgumentException("Cannot read file '" + filePath + "'.");

--- a/src/test/java/ca/nexapp/core/infrastructure/files/reader/ByLineFileReaderITest.java
+++ b/src/test/java/ca/nexapp/core/infrastructure/files/reader/ByLineFileReaderITest.java
@@ -2,6 +2,8 @@ package ca.nexapp.core.infrastructure.files.reader;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Before;
@@ -9,7 +11,6 @@ import org.junit.Test;
 
 public class ByLineFileReaderITest {
 
-    private static final String FILE_PATH = "/aFile.txt";
     private static final String UNEXISTING_FILE = "aaaaa";
 
     private static final int NUMBER_OF_LINES_IN_FILE = 3;
@@ -18,23 +19,25 @@ public class ByLineFileReaderITest {
     private static final String SECOND_LINE = "second line";
     private static final String THIRD_LINE = "third line";
 
+    private String filePath;
     private FileReader<List<String>> fileReader;
 
     @Before
-    public void setUp() {
+    public void setUp() throws URISyntaxException {
         fileReader = new ByLineFileReader();
+        filePath = Paths.get(getClass().getResource("/aFile.txt").toURI()).toString();
     }
 
     @Test
     public void givenAFileWhenReadingItShouldReturnTheExactSameNumberOfLines() {
-        List<String> lines = fileReader.read(FILE_PATH);
+        List<String> lines = fileReader.read(filePath);
 
         assertThat(lines).hasSize(NUMBER_OF_LINES_IN_FILE);
     }
 
     @Test
     public void givenAFileWhenReadingItShouldCorrespondToTheExpectedContent() {
-        List<String> lines = fileReader.read(FILE_PATH);
+        List<String> lines = fileReader.read(filePath);
 
         assertThat(lines).containsExactly(FIRST_LINE, SECOND_LINE, THIRD_LINE).inOrder();
     }

--- a/src/test/java/ca/nexapp/core/infrastructure/files/reader/CSVFileReaderITest.java
+++ b/src/test/java/ca/nexapp/core/infrastructure/files/reader/CSVFileReaderITest.java
@@ -2,6 +2,8 @@ package ca.nexapp.core.infrastructure.files.reader;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Before;
@@ -9,7 +11,6 @@ import org.junit.Test;
 
 public class CSVFileReaderITest {
 
-    private static final String FILE_PATH = "/csvFile.csv";
     private static final String UNEXISTING_FILE = "aaaaa";
 
     private static final int NUMBER_OF_LINES_IN_FILE = 2;
@@ -17,23 +18,25 @@ public class CSVFileReaderITest {
     private static final String[] FIRST_LINE = { "a", "b", "c" };
     private static final String[] SECOND_LINE = { "1", "2", "3" };
 
+    private String filePath;
     private FileReader<List<String[]>> fileReader;
 
     @Before
-    public void setUp() {
+    public void setUp() throws URISyntaxException {
         fileReader = new CSVFileReader();
+        filePath = Paths.get(getClass().getResource("/csvFile.csv").toURI()).toString();
     }
 
     @Test
     public void givenAFile_WhenReadingIt_ShouldReturnTheExactSameNumberOfLines() {
-        List<String[]> lines = fileReader.read(FILE_PATH);
+        List<String[]> lines = fileReader.read(filePath);
 
         assertThat(lines).hasSize(NUMBER_OF_LINES_IN_FILE);
     }
 
     @Test
     public void givenAFile_WhenReadingIt_ShouldCorrespondToTheExpectedContent() {
-        List<String[]> lines = fileReader.read(FILE_PATH);
+        List<String[]> lines = fileReader.read(filePath);
 
         assertThat(lines.get(0)).isEqualTo(FIRST_LINE);
         assertThat(lines.get(1)).isEqualTo(SECOND_LINE);


### PR DESCRIPTION
If we want to pass a path from the computer not from the resource of a projet, the file reader throw an exception. This merge request fix this.