### PR TITLE
Fix password equality

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Then, you simply add the dependency as follows:
 <dependency>
 	<groupId>ca.nexapp</groupId>
 	<artifactId>core</artifactId>
-	<version>0.1.1</version>
+	<version>0.1.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>ca.nexapp</groupId>
     <artifactId>core</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <packaging>jar</packaging>
 
     <name>Nexapp Core</name>

--- a/src/main/java/ca/nexapp/core/authentication/Password.java
+++ b/src/main/java/ca/nexapp/core/authentication/Password.java
@@ -1,6 +1,6 @@
 package ca.nexapp.core.authentication;
 
-import java.util.Objects;
+import java.util.Arrays;
 
 import ca.nexapp.core.authentication.hashers.PasswordHasher;
 import ca.nexapp.core.authentication.salts.SaltGenerator;
@@ -31,7 +31,7 @@ public class Password {
 
     @Override
     public int hashCode() {
-        return Objects.hash(hashed, salt);
+        return Arrays.deepHashCode(new Object[]{hashed, salt});
     }
 
     @Override
@@ -41,8 +41,8 @@ public class Password {
         }
 
         Password other = (Password) obj;
-        return Objects.equals(hashed, other.hashed)
-                && Objects.equals(salt, other.salt);
+        return Arrays.equals(hashed, other.hashed)
+                && Arrays.equals(salt, other.salt);
     }
 
     public static Password fromPlaintext(String plaintext, SaltGenerator saltGenerator, PasswordHasher passwordHasher) {

--- a/src/test/java/ca/nexapp/core/authentication/PasswordTest.java
+++ b/src/test/java/ca/nexapp/core/authentication/PasswordTest.java
@@ -1,0 +1,30 @@
+package ca.nexapp.core.authentication;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PasswordTest {
+
+    byte[] aSalt = new byte[]{1, 2, 3, 4};
+    byte[] aHash = new byte[]{11, 22, 33, 44, 55, 66, 77, 88};
+
+    @Test
+    public void givenASameHashAndSalt_ShouldBeEquals() {
+        Password password1 = Password.fromHash(aHash, aSalt, null);
+        Password password2 = Password.fromHash(aHash.clone(), aSalt.clone(), null);
+
+        assertThat(password1).isEqualTo(password2);
+    }
+
+    @Test
+    public void givenASameHashAndSalt_ShouldHaveEqualsHashCode() {
+        int password1HashCode = Password.fromHash(aHash, aSalt, null).hashCode();
+        int password2HashCode = Password.fromHash(aHash.clone(), aSalt.clone(), null).hashCode();
+
+        assertThat(password1HashCode).isEqualTo(password2HashCode);
+    }
+}

--- a/src/test/java/ca/nexapp/core/authentication/PasswordTest.java
+++ b/src/test/java/ca/nexapp/core/authentication/PasswordTest.java
@@ -1,7 +1,9 @@
 package ca.nexapp.core.authentication;
 
+import ca.nexapp.core.authentication.hashers.PasswordHasher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -9,22 +11,59 @@ import static com.google.common.truth.Truth.assertThat;
 @RunWith(MockitoJUnitRunner.class)
 public class PasswordTest {
 
-    byte[] aSalt = new byte[]{1, 2, 3, 4};
-    byte[] aHash = new byte[]{11, 22, 33, 44, 55, 66, 77, 88};
+    @Mock
+    PasswordHasher passwordHasher;
+
+    private static final byte[] A_SALT = new byte[]{1, 2, 3, 4};
+    private static final byte[] ANOTHER_SALT = new byte[]{5, 6, 7, 8};
+    private static final byte[] A_HASH = new byte[]{11, 22, 33, 44, 55, 66, 77, 88};
+    private static final byte[] ANOTHER_HASH = new byte[]{12, 23, 34, 45, 56, 67, 78, 89};
 
     @Test
-    public void givenASameHashAndSalt_ShouldBeEquals() {
-        Password password1 = Password.fromHash(aHash, aSalt, null);
-        Password password2 = Password.fromHash(aHash.clone(), aSalt.clone(), null);
+    public void givenPasswordsWithEquivalentHashAndSalt_ShouldBeEquals() {
+        Password password1 = Password.fromHash(A_HASH, A_SALT, passwordHasher);
+        Password password2 = Password.fromHash(A_HASH.clone(), A_SALT.clone(), passwordHasher);
 
         assertThat(password1).isEqualTo(password2);
     }
 
     @Test
-    public void givenASameHashAndSalt_ShouldHaveEqualsHashCode() {
-        int password1HashCode = Password.fromHash(aHash, aSalt, null).hashCode();
-        int password2HashCode = Password.fromHash(aHash.clone(), aSalt.clone(), null).hashCode();
+    public void givenPasswordsWithDifferentHash_ShouldNotBeEquals() {
+        Password password1 = Password.fromHash(A_HASH, A_SALT, passwordHasher);
+        Password password2 = Password.fromHash(ANOTHER_HASH, A_SALT.clone(), passwordHasher);
+
+        assertThat(password1).isNotEqualTo(password2);
+    }
+
+    @Test
+    public void givenPasswordsWithDifferentSalt_ShouldNotBeEquals() {
+        Password password1 = Password.fromHash(A_HASH, A_SALT, passwordHasher);
+        Password password2 = Password.fromHash(A_HASH.clone(), ANOTHER_SALT, passwordHasher);
+
+        assertThat(password1).isNotEqualTo(password2);
+    }
+
+    @Test
+    public void givenPasswordsWithEquivalentHashAndSalt_ShouldHaveEqualsHashCode() {
+        int password1HashCode = Password.fromHash(A_HASH, A_SALT, passwordHasher).hashCode();
+        int password2HashCode = Password.fromHash(A_HASH.clone(), A_SALT.clone(), passwordHasher).hashCode();
 
         assertThat(password1HashCode).isEqualTo(password2HashCode);
+    }
+
+    @Test
+    public void givenPasswordsWithDifferentHash_ShouldNotHaveEqualsHashCode() {
+        int password1HashCode = Password.fromHash(A_HASH, A_SALT, passwordHasher).hashCode();
+        int password2HashCode = Password.fromHash(ANOTHER_HASH, A_SALT.clone(), passwordHasher).hashCode();
+
+        assertThat(password1HashCode).isNotEqualTo(password2HashCode);
+    }
+
+    @Test
+    public void givenPasswordsWithDifferentSalt_ShouldNotHaveEqualsHashCode() {
+        int password1HashCode = Password.fromHash(A_HASH, A_SALT, passwordHasher).hashCode();
+        int password2HashCode = Password.fromHash(A_HASH.clone(), ANOTHER_SALT, passwordHasher).hashCode();
+
+        assertThat(password1HashCode).isNotEqualTo(password2HashCode);
     }
 }


### PR DESCRIPTION
Use appropriate equals and hashCode methods for password.

Array.equals compare only the content of the array and does not requires the same array instance like Object.equals.
Objects.hash use only the identity of the array, not the content.